### PR TITLE
Add email to mandrill webhook

### DIFF
--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
@@ -6,9 +6,14 @@ type Event interface {
 }
 
 type MandrillEvent struct {
-	EventName string `json:"event"`
-	TimeStamp int64  `json:"ts"`
-	Id        string `json:"_id"`
+	EventName string  `json:"event"`
+	TimeStamp int64   `json:"ts"`
+	Id        string  `json:"_id"`
+	Msg       Message `json:"msg"`
+}
+
+type Message struct {
+	Email string `json:"email"`
 }
 
 func (me *MandrillEvent) Tags() map[string]string {
@@ -19,6 +24,7 @@ func (me *MandrillEvent) Tags() map[string]string {
 
 func (me *MandrillEvent) Fields() map[string]interface{} {
 	return map[string]interface{}{
-		"id": me.Id,
+		"id":    me.Id,
+		"email": me.Msg.Email,
 	}
 }

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -46,7 +46,8 @@ func TestSendEvent(t *testing.T) {
 	}
 
 	fields := map[string]interface{}{
-		"id": "id1",
+		"id":    "id1",
+		"email": "example.webhook@mandrillapp.com",
 	}
 
 	tags := map[string]string{
@@ -65,7 +66,8 @@ func TestMultipleEvents(t *testing.T) {
 	}
 
 	fields := map[string]interface{}{
-		"id": "id1",
+		"id":    "id1",
+		"email": "example.webhook@mandrillapp.com",
 	}
 
 	tags := map[string]string{
@@ -75,7 +77,8 @@ func TestMultipleEvents(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
 
 	fields = map[string]interface{}{
-		"id": "id2",
+		"id":    "id2",
+		"email": "example.webhook@mandrillapp.com",
 	}
 
 	tags = map[string]string{


### PR DESCRIPTION
This adds email address to the mandrill webhook so that we can
also see what emails are bouncing.